### PR TITLE
Fix libcd:or behaving like an "and"

### DIFF
--- a/src/main/java/io/github/cottonmc/libcd/condition/ConditionalData.java
+++ b/src/main/java/io/github/cottonmc/libcd/condition/ConditionalData.java
@@ -67,7 +67,7 @@ public class ConditionalData {
 					if (elem instanceof JsonObject) {
 						JsonObject obj = (JsonObject) elem;
 						for (String key : obj.keySet()) {
-							if (!testCondition(new Identifier(key), obj)) return false;
+							if (testCondition(new Identifier(key), parseElement(obj.get(key)))) return true;
 						}
 					}
 				}


### PR DESCRIPTION
`libcd:or` currently returns false if any condition fails. This PR changes it to return true if any condition succeeds.