### PR TITLE
Update to 20w15a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=20w14a
-yarn_build=10
+minecraft_version=20w15a
+yarn_build=4
 loader_version=0.8.2+build.194
 
 # Mod Properties
@@ -14,5 +14,5 @@ archives_base_name = libcd
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.5.8+build.316-1.16
+fabric_version=0.5.10+build.320-1.16
 jankson_version=2.0.1+j1.2.0

--- a/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
+++ b/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
@@ -18,19 +18,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Mixin(Tag.Builder.class)
 public class MixinTagBuilder implements TagBuilderWarningAccessor {
-    @Shadow
-    @Final
-    private Set<Tag.Entry> entries;
 
+    @Shadow @Final private List<Tag.class_5145> entries;
     @Unique
     private final List<Object> libcdWarnings = new ArrayList<>();
 
-    @Inject(method = "read", at = @At(value = "INVOKE", target = "Ljava/util/Set;addAll(Ljava/util/Collection;)Z", remap = false))
-    private void onFromJson(JsonObject json, CallbackInfoReturnable<Tag.Builder> cir) {
+    @Inject(method = "read", at = @At(value = "RETURN", remap = false))
+    private void onFromJson(JsonObject json, String string, CallbackInfoReturnable<Tag.Builder> cir) {
         try {
             if (json.has("libcd")) {
                 TagExtensions.ExtensionResult result = TagExtensions.load(
@@ -43,7 +40,10 @@ public class MixinTagBuilder implements TagBuilderWarningAccessor {
                     entries.clear();
                 }
 
-                entries.addAll(result.getEntries());
+                result.getEntries().forEach((entry) -> {
+                    this.entries.add(class_5145Accessor.createClass_5145(entry, string));
+                });
+
                 libcdWarnings.addAll(result.getWarnings());
             }
         } catch (Exception e) {

--- a/src/main/java/io/github/cottonmc/libcd/mixin/class_5145Accessor.java
+++ b/src/main/java/io/github/cottonmc/libcd/mixin/class_5145Accessor.java
@@ -1,0 +1,13 @@
+package io.github.cottonmc.libcd.mixin;
+
+import net.minecraft.tag.Tag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Tag.class_5145.class)
+public interface class_5145Accessor {
+    @Invoker("<init>")
+    static Tag.class_5145 createClass_5145(Tag.Entry entry, String string) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/resources/mixins.libcd.json
+++ b/src/main/resources/mixins.libcd.json
@@ -3,6 +3,7 @@
   "package": "io.github.cottonmc.libcd.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "class_5145Accessor",
     "MixinAdvancementRewards",
     "MixinAdvancementRewardsDeserializer",
     "MixinIngredient",


### PR DESCRIPTION
20w15a adds a new Tag inner class (currently called `class_5145`). It has a `Tag.Entry` and `String`, with the String being `resource.getResourcePackName()`. It seems to only be used for logging.

`Tag.Builder#read` was also refactored a small amount. Instead of calling `entries.addAll(list)`, entries are now added with `forEach`:
```java
list.forEach((entry) -> {
     this.entries.add(new Tag.class_5145(entry, string));
});
```

This PR updates dependency versions, and changes the mixin in the previously mentioned class to go at `RETURN` (previous injection point was removed, might as well go at return). 

Main issue, obviously, is that `class_5145` doesn't have a name yet. I can keep it as is (and update when the class is mapped), PR a name to yarn myself and wait, or guess at a name here. Also let me know if you'd like me to bump the version.