### PR TITLE
Fix tag extensions

### DIFF
--- a/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
+++ b/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
@@ -33,7 +33,7 @@ public class MixinTagBuilder implements TagBuilderWarningAccessor {
     private void onFromJson(JsonObject json, String string, CallbackInfoReturnable<Tag.Builder> info) {
         try {
             if (json.has("libcd")) {
-                TagExtensions.ExtensionResult result = TagExtensions.load(json);
+                TagExtensions.ExtensionResult result = TagExtensions.load(json.getAsJsonObject("libcd"));
 
                 if (result.shouldReplace()) {
                     entries.clear();

--- a/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
+++ b/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java
@@ -7,6 +7,7 @@ import io.github.cottonmc.libcd.tag.ItemTagHelper;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -33,7 +34,7 @@ public class MixinTagBuilder implements TagBuilderWarningAccessor {
     private void onFromJson(JsonObject json, String string, CallbackInfoReturnable<Tag.Builder> info) {
         try {
             if (json.has("libcd")) {
-                TagExtensions.ExtensionResult result = TagExtensions.load(json.getAsJsonObject("libcd"));
+                TagExtensions.ExtensionResult result = TagExtensions.load(JsonHelper.getObject(json, "libcd"));
 
                 if (result.shouldReplace()) {
                     entries.clear();


### PR DESCRIPTION
When migrating to Gson, this conversion code from `JsonHelper.getObject(json, "libcd")` to a Jankson `JsonObject`:

https://github.com/CottonMC/LibCD/blob/4f8a5531eff58d1bc27f3437c47289b1dcf66f45/src/main/java/io/github/cottonmc/libcd/mixin/MixinTagBuilder.java#L46-L51

became just `json` instead, which is actually the root object instead of the `libcd` block. This PR restores the old method call and fixes tag extensions.