### PR TITLE
Fixed invalid entry

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,7 @@
   "name": "LibCapableData",
   "icon": "assets/libcd/icon.png",
   "description": "Various tweaks to make data packs even more useful!",
-  "licence": "MIT",
+  "license": "MIT",
   "contact": {
     "sources": "https://github.com/CottonMC/LibCD"
   },


### PR DESCRIPTION
The mod "libcd" contains invalid entries in its mod json:
- Unsupported root entry "licence" at line 9 column 12